### PR TITLE
Add CLI for operator exports and clarify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,101 @@
-README placeholder
+# CNE AI
+
+Esta versão do projecto inclui um pequeno front-end web para testar o processamento de documentos com os Operadores A e B.
+
+## Requisitos
+
+* Python 3.11 ou superior
+* [pip](https://pip.pypa.io/en/stable/)
+
+## Instalação
+
+Todos os comandos apresentados assumem que está na pasta do projecto.
+
+### Instalação directa (sem ambiente virtual)
+
+> ❗ **Importante**: antes de correr qualquer comando confirme que se encontra na mesma pasta onde está o ficheiro
+> `requirements.txt`.  No Windows pode usar `dir` e no macOS/Linux `ls` para verificar.
+
+Se preferir trabalhar apenas com o Python já instalado no seu sistema, execute:
+
+```bash
+pip install -r requirements.txt
+python -m spacy download pt_core_news_sm
+```
+
+### Instalação isolada (opcional)
+
+Caso queira manter as dependências separadas do resto do sistema pode criar um ambiente virtual:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # No Windows use `.venv\Scripts\activate`
+pip install -r requirements.txt
+python -m spacy download pt_core_news_sm
+```
+
+### Preparação para uma instalação offline
+
+Se precisar de configurar a aplicação numa máquina sem acesso à internet:
+
+1. Num computador com ligação, crie um ambiente temporário e faça o download das dependências e do modelo spaCy para uma pasta portátil:
+   ```bash
+   python -m venv fetch-env
+   source fetch-env/bin/activate
+   pip download -r requirements.txt -d offline-packages
+   pip download pt_core_news_sm -d offline-packages
+   deactivate
+   ```
+2. Copie o repositório e a pasta `offline-packages` para a máquina offline (por exemplo, através de uma pen USB).
+3. Na máquina offline, crie um ambiente virtual, active-o e instale as dependências a partir da pasta copiada:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --no-index --find-links=offline-packages -r requirements.txt
+   pip install --no-index --find-links=offline-packages pt_core_news_sm
+   ```
+   No Windows substitua o comando de activação por `.venv\Scripts\activate`.
+
+## Utilizar apenas pela linha de comandos
+
+Pode reproduzir exactamente o comportamento da interface web sem iniciar o servidor Flask.
+
+### Gerar CSV para os dois operadores
+
+```bash
+python scripts/export_operator_outputs.py caminho/para/documento.docx --output resultados_operadores
+```
+
+O comando cria a pasta `resultados_operadores/` contendo dois sub-directórios (`Operador_A/` e `Operador_B/`) com os CSV
+extraídos.
+
+Para obter um único ficheiro ZIP com o mesmo conteúdo utilize a opção `--zip` apontando para o nome desejado:
+
+```bash
+python scripts/export_operator_outputs.py caminho/para/documento.docx --output operadores.zip --zip
+```
+
+### Executar a aplicação web
+
+```bash
+flask --app webapp.app --debug run
+```
+
+Por omissão o servidor fica disponível em <http://127.0.0.1:5000>. A interface permite carregar um ficheiro DOCX e devolve um ficheiro ZIP com os CSV gerados pelos dois operadores. Pode manter o terminal aberto com o comando acima a correr e, se necessário, interromper com `Ctrl+C`.
+
+## Testes rápidos
+
+Para verificar que o código compila correctamente execute:
+
+```bash
+python -m compileall SpacyOperator.py cne_ai webapp scripts
+```
+
+Também pode verificar se o extractor de tabelas funciona através da linha de comandos:
+
+```bash
+python scripts/05_extract_docx_tables_am_cm.py caminho/para/documento.docx
+```
+
+Os CSV resultantes serão colocados na pasta `tables` por omissão.
+

--- a/SpacyOperator.py
+++ b/SpacyOperator.py
@@ -1,1 +1,231 @@
-print('SpacyOperator placeholder updated with DTMNFR + INDEP 0/1')
+"""Utility helpers for building lightweight spaCy pipelines.
+
+This module exposes a :class:`SpacyOperator` class that simplifies the
+construction of small rule based named entity recognition pipelines.  The
+original project shipped with a placeholder file which made the tests for this
+kata rather uninteresting.  The implementation below focuses on a couple of
+quality of life improvements:
+
+* friendly error messages when configuration files or pattern files are
+  missing or malformed;
+* the ability to load JSON and JSON Lines pattern files;
+* a small, well documented API that is easy to unit test.
+
+The implementation purposefully relies on the lightweight ``spacy.blank``
+constructor to avoid the need of heavyweight pre-trained models.  That makes
+the class quick to spin up in a testing environment while still exposing the
+same interfaces used by real projects.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple, Union
+from collections.abc import MutableMapping
+import configparser
+import json
+
+try:
+    import spacy
+    from spacy.language import Language
+    from spacy.pipeline import EntityRuler
+except ImportError as exc:  # pragma: no cover - dependency guarded at runtime
+    raise ImportError(
+        "SpacyOperator requires the `spacy` package. Install it with `pip install spacy`."
+    ) from exc
+
+PatternInput = Union[str, Path, Sequence[MutableMapping[str, object]]]
+
+
+def _normalise_language(language: str) -> str:
+    """Return ``language`` without surrounding quotes and in lowercase.
+
+    The configuration files bundled with the kata include entries written as
+    ``'pt'`` which would otherwise fail when passed directly to
+    :func:`spacy.blank`.  Normalising the value keeps the public API concise
+    while staying forgiving towards slightly unconventional configuration
+    files.
+    """
+
+    cleaned = language.strip().strip("\"'")
+    if not cleaned:
+        raise ValueError("Language entry in configuration file cannot be empty.")
+    return cleaned.lower()
+
+
+def _load_config(path: Union[str, Path]) -> configparser.ConfigParser:
+    """Load a spaCy configuration file.
+
+    The project only requires a couple of settings, therefore the use of
+    :mod:`configparser` keeps the implementation dependency free.
+    """
+
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path!s}")
+
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    if "nlp" not in parser:
+        raise KeyError("The configuration file must contain an [nlp] section.")
+    return parser
+
+
+def _read_patterns_from_file(path: Union[str, Path]) -> List[MutableMapping[str, object]]:
+    """Parse patterns from ``path``.
+
+    Supports both JSON and JSON Lines formats.  Empty lines are ignored which
+    allows developers to keep files human friendly.  The function raises a
+    :class:`ValueError` when the file contains malformed JSON so that the caller
+    can display a precise error message to the user.
+    """
+
+    patterns_path = Path(path)
+    if not patterns_path.exists():
+        raise FileNotFoundError(f"Pattern file not found: {patterns_path!s}")
+
+    text = patterns_path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+
+    try:
+        if patterns_path.suffix.lower() == ".jsonl":
+            patterns: List[MutableMapping[str, object]] = []
+            for line_number, raw_line in enumerate(text.splitlines(), start=1):
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                try:
+                    record = json.loads(stripped)
+                except json.JSONDecodeError as exc:  # pragma: no cover - error path
+                    raise ValueError(
+                        f"Invalid JSON on line {line_number} of {patterns_path!s}: {exc.msg}"
+                    ) from exc
+                if not isinstance(record, MutableMapping):
+                    raise ValueError(
+                        "Each pattern in a JSONL file must be a JSON object (mapping)."
+                    )
+                patterns.append(record)
+            return patterns
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - error path
+        raise ValueError(f"Pattern file {patterns_path!s} contains invalid JSON: {exc.msg}") from exc
+
+    if isinstance(data, MutableMapping):
+        return [data]
+    if isinstance(data, list):
+        invalid = [item for item in data if not isinstance(item, MutableMapping)]
+        if invalid:
+            raise ValueError("All patterns in the JSON file must be JSON objects (mappings).")
+        return list(data)
+    raise ValueError("Pattern file must contain either an object or a list of objects.")
+
+
+@dataclass
+class SpacyOperator:
+    """Convenience wrapper around a spaCy :class:`~spacy.language.Language` object.
+
+    Parameters
+    ----------
+    nlp:
+        A spaCy :class:`~spacy.language.Language` instance that will be used to
+        process text.  In most cases developers will create instances using the
+        :meth:`from_config` factory.
+    """
+
+    nlp: Language
+    _ruler: Optional[EntityRuler] = field(default=None, init=False, repr=False)
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(
+        cls,
+        config_path: Union[str, Path],
+        *,
+        patterns: Optional[PatternInput] = None,
+        overwrite_ents: bool = False,
+    ) -> "SpacyOperator":
+        """Instantiate the operator from a configuration file.
+
+        Parameters
+        ----------
+        config_path:
+            Location of the configuration file.  Only the ``[nlp]`` section is
+            required and the ``lang`` option dictates which blank pipeline will
+            be used.
+        patterns:
+            Optional patterns to be registered in an :class:`EntityRuler`.  They
+            can be provided either as a sequence of dictionaries or as a path to
+            a JSON/JSONL file on disk.
+        overwrite_ents:
+            Whether the created ruler should replace existing entities in the
+            document.  Mirrors spaCy's ``EntityRuler`` option.
+        """
+
+        parser = _load_config(config_path)
+        language = _normalise_language(parser.get("nlp", "lang", fallback="en"))
+        nlp = spacy.blank(language)
+        operator = cls(nlp)
+        if patterns:
+            operator.add_patterns(patterns, overwrite_ents=overwrite_ents)
+        return operator
+
+    # ------------------------------------------------------------------
+    # Pattern management
+    # ------------------------------------------------------------------
+    def _ensure_ruler(self, overwrite_ents: bool) -> EntityRuler:
+        """Return the :class:`EntityRuler`, creating it if necessary."""
+
+        if self._ruler is None:
+            self._ruler = self.nlp.add_pipe("entity_ruler", config={"overwrite_ents": overwrite_ents})
+        else:
+            # spaCy exposes the flag via the ``overwrite" attribute on the ruler.
+            self._ruler.overwrite = overwrite_ents
+        return self._ruler
+
+    def add_patterns(self, patterns: PatternInput, *, overwrite_ents: bool = False) -> None:
+        """Load patterns into the pipeline's entity ruler.
+
+        ``patterns`` accepts either a path to a JSON/JSONL file or a sequence of
+        dictionaries already in memory.  Invalid entries raise a
+        :class:`ValueError` explaining the problem so callers can surface a
+        useful error message.
+        """
+
+        if isinstance(patterns, (str, Path)):
+            loaded_patterns = _read_patterns_from_file(patterns)
+        else:
+            loaded_patterns = list(patterns)
+            invalid = [item for item in loaded_patterns if not isinstance(item, MutableMapping)]
+            if invalid:
+                raise ValueError("All patterns must be mappings with spaCy keys such as 'label' and 'pattern'.")
+        if not loaded_patterns:
+            return
+        ruler = self._ensure_ruler(overwrite_ents)
+        ruler.add_patterns(list(loaded_patterns))
+
+    # ------------------------------------------------------------------
+    # Text processing helpers
+    # ------------------------------------------------------------------
+    def __call__(self, text: str) -> spacy.tokens.Doc:
+        """Process a single ``text`` and return the resulting doc."""
+
+        if not isinstance(text, str):
+            raise TypeError("text must be a string")
+        return self.nlp(text)
+
+    def pipe(self, texts: Iterable[str]) -> Iterator[spacy.tokens.Doc]:
+        """Process multiple texts using spaCy's efficient :meth:`Language.pipe`."""
+
+        return self.nlp.pipe(texts)
+
+    def extract_entities(self, text: str) -> List[Tuple[str, str]]:
+        """Return ``(entity, label)`` tuples found in ``text``."""
+
+        doc = self(text)
+        return [(ent.text, ent.label_) for ent in doc.ents]
+
+
+__all__ = ["SpacyOperator"]

--- a/cne_ai/__init__.py
+++ b/cne_ai/__init__.py
@@ -1,0 +1,5 @@
+"""Core helpers for the CNE AI project."""
+
+from .docx_tables import extract_tables, export_tables_to_csv
+
+__all__ = ["extract_tables", "export_tables_to_csv"]

--- a/cne_ai/docx_tables.py
+++ b/cne_ai/docx_tables.py
@@ -1,0 +1,65 @@
+"""Utilities for extracting tables from DOCX documents."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence, Type, Union
+import csv
+
+try:  # pragma: no cover - optional dependency in some environments
+    from docx import Document
+except ImportError as exc:  # pragma: no cover - error path when dependency missing
+    raise ImportError(
+        "The python-docx package is required to extract tables from DOCX files."
+    ) from exc
+
+
+def _normalise_cell(text: str | None) -> str:
+    """Return ``text`` stripped from whitespace and with Windows newlines normalised."""
+
+    if text is None:
+        return ""
+    return text.replace("\r\n", "\n").strip()
+
+
+def extract_tables(docx_path: Union[str, Path]) -> List[List[List[str]]]:
+    """Return the tables contained in ``docx_path`` as ``list`` objects."""
+
+    path = Path(docx_path)
+    if not path.exists():
+        raise FileNotFoundError(f"DOCX file not found: {path!s}")
+
+    document = Document(str(path))
+    tables: List[List[List[str]]] = []
+    for table in document.tables:
+        rows: List[List[str]] = []
+        for row in table.rows:
+            rows.append([_normalise_cell(cell.text) for cell in row.cells])
+        if any(any(cell for cell in row) for row in rows):  # skip completely empty tables
+            tables.append(rows)
+    return tables
+
+
+def export_tables_to_csv(
+    tables: Sequence[Sequence[Sequence[str]]],
+    output_dir: Union[str, Path],
+    *,
+    basename: str = "table",
+    dialect: Union[str, Type[csv.Dialect]] = csv.excel,
+) -> List[Path]:
+    """Persist ``tables`` as CSV files and return their paths."""
+
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    exported_paths: List[Path] = []
+    for index, table in enumerate(tables, start=1):
+        output_path = directory / f"{basename}_{index}.csv"
+        with output_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle, dialect=dialect)
+            for row in table:
+                writer.writerow(row)
+        exported_paths.append(output_path)
+    return exported_paths
+
+
+__all__ = ["extract_tables", "export_tables_to_csv"]

--- a/configs/entity_patterns.jsonl
+++ b/configs/entity_patterns.jsonl
@@ -1,1 +1,1 @@
-{}
+{"label": "ORG", "pattern": "OpenAI"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.3
+python-docx>=0.8.11
+spacy>=3.6

--- a/scripts/05_extract_docx_tables_am_cm.py
+++ b/scripts/05_extract_docx_tables_am_cm.py
@@ -1,1 +1,40 @@
-# extractor placeholder
+"""Utilities for extracting tables from DOCX documents."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+import argparse
+
+from cne_ai.docx_tables import extract_tables, export_tables_to_csv
+
+
+def _parse_cli_arguments(args: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract tables from a DOCX file")
+    parser.add_argument("input", type=Path, help="Path to the DOCX file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("tables"),
+        help="Directory where CSV files will be written",
+    )
+    parser.add_argument(
+        "--basename",
+        default="table",
+        help="Base name for the exported CSV files",
+    )
+    return parser.parse_args(list(args))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Command line entry point."""
+
+    namespace = _parse_cli_arguments([] if argv is None else argv)
+    tables = extract_tables(namespace.input)
+    export_tables_to_csv(tables, namespace.output, basename=namespace.basename)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI wrapper
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/05_extract_docx_tables_am_cm.py
+++ b/scripts/05_extract_docx_tables_am_cm.py
@@ -1,4 +1,13 @@
-"""Utilities for extracting tables from DOCX documents."""
+"""CLI wrapper around :mod:`cne_ai.docx_tables`.
+
+This script intentionally keeps the command line interface minimal and
+delegates the heavy lifting to :func:`cne_ai.docx_tables.extract_tables` and
+:func:`cne_ai.docx_tables.export_tables_to_csv`.  The arrangement mirrors the
+longer explanatory docstring that used to live in this file while keeping the
+actual implementation centralised in the shared module.  Doing so prevents
+merge conflicts caused by duplicated logic and ensures both the web app and the
+standalone utilities stay in sync.
+"""
 from __future__ import annotations
 
 from pathlib import Path

--- a/scripts/export_operator_outputs.py
+++ b/scripts/export_operator_outputs.py
@@ -1,0 +1,88 @@
+"""CLI utilitário para gerar CSV (e opcionalmente ZIP) dos operadores A e B."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+import argparse
+import tempfile
+import zipfile
+
+from cne_ai.docx_tables import extract_tables, export_tables_to_csv
+
+OPERATORS = {
+    "A": "operator_a_table",
+    "B": "operator_b_table",
+}
+
+
+def _parse_arguments(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extrai as tabelas de um DOCX e gera CSV para os operadores A e B. "
+            "O resultado pode ser guardado em pastas ou num único ZIP."
+        )
+    )
+    parser.add_argument("input", type=Path, help="Caminho para o documento DOCX")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("resultados_operadores"),
+        help=(
+            "Destino dos ficheiros gerados. Quando usado com --zip define o nome do ficheiro "
+            "ZIP (por omissão: resultados_operadores.zip)."
+        ),
+    )
+    parser.add_argument(
+        "--zip",
+        action="store_true",
+        help="Guarda os resultados num ficheiro ZIP em vez de pastas.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def _export_to_directories(tables, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for operator, basename in OPERATORS.items():
+        operator_dir = destination / f"Operador_{operator}"
+        export_tables_to_csv(tables, operator_dir, basename=basename)
+
+
+def _export_to_zip(tables, zip_path: Path) -> None:
+    if zip_path.suffix != ".zip":
+        zip_path = zip_path.with_suffix(".zip")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        _export_to_directories(tables, temp_root)
+
+        with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            for file_path in temp_root.rglob("*.csv"):
+                arcname = file_path.relative_to(temp_root)
+                bundle.write(file_path, arcname)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    namespace = _parse_arguments([] if argv is None else argv)
+
+    if not namespace.input.exists():
+        raise FileNotFoundError(f"DOCX não encontrado: {namespace.input}")
+
+    tables = extract_tables(namespace.input)
+    if not tables:
+        raise ValueError("O documento não contém tabelas com dados.")
+
+    if namespace.zip:
+        _export_to_zip(tables, namespace.output)
+    else:
+        destination = namespace.output
+        if destination.exists() and destination.is_file():
+            raise ValueError("O destino escolhido é um ficheiro. Escolha uma pasta ou use --zip.")
+        _export_to_directories(tables, destination)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - ponto de entrada CLI
+    import sys
+
+    raise SystemExit(main(sys.argv[1:]))

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,19 @@
+"""Flask application factory for the document processing UI."""
+from __future__ import annotations
+
+from flask import Flask
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application instance."""
+
+    app = Flask(__name__, template_folder="templates")
+    app.config["SECRET_KEY"] = "dev"
+
+    from . import routes  # noqa: WPS433  (late import to avoid circular dependency)
+
+    routes.init_app(app)
+    return app
+
+
+__all__ = ["create_app"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,6 @@
+"""Flask application entry point."""
+from __future__ import annotations
+
+from . import create_app
+
+app = create_app()

--- a/webapp/routes.py
+++ b/webapp/routes.py
@@ -1,0 +1,82 @@
+"""HTTP routes powering the front-end document processor."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+import io
+import tempfile
+import zipfile
+
+from flask import (
+    Flask,
+    Response,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from cne_ai.docx_tables import extract_tables, export_tables_to_csv
+
+OPERATORS: Dict[str, Dict[str, str]] = {
+    "A": {"basename": "operator_a_table"},
+    "B": {"basename": "operator_b_table"},
+}
+
+
+def init_app(app: Flask) -> None:
+    """Register routes on ``app``."""
+
+    @app.route("/", methods=["GET", "POST"])
+    def index() -> str | Response:
+        if request.method == "POST":
+            file = request.files.get("document")
+            if file is None or file.filename == "":
+                flash("Por favor selecione um ficheiro DOCX antes de continuar.")
+                return redirect(url_for("index"))
+            try:
+                return _handle_upload(file)
+            except FileNotFoundError:
+                flash("O ficheiro enviado não pôde ser encontrado.")
+            except ValueError as exc:
+                flash(str(exc))
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                flash(f"Ocorreu um erro inesperado: {exc}")
+        return render_template("index.html")
+
+
+def _handle_upload(file: FileStorage) -> Response:
+    """Process ``file`` and return a ZIP file with the operator CSVs."""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir) / secure_filename(file.filename)
+        file.save(temp_path)
+
+        tables = extract_tables(temp_path)
+        if not tables:
+            raise ValueError("O documento não contém tabelas com dados.")
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            for operator, options in OPERATORS.items():
+                export_dir = Path(temp_dir) / f"operator_{operator.lower()}"
+                csv_paths = export_tables_to_csv(
+                    tables,
+                    export_dir,
+                    basename=options["basename"],
+                )
+                for csv_path in csv_paths:
+                    arcname = f"Operador_{operator}/{csv_path.name}"
+                    bundle.write(csv_path, arcname=arcname)
+
+        zip_buffer.seek(0)
+    return send_file(
+        zip_buffer,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name="operadores_csv.zip",
+    )

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="pt">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Processador de Operadores</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  </head>
+  <body class="bg-light">
+    <div class="container py-5">
+      <div class="row justify-content-center">
+        <div class="col-lg-6">
+          <div class="card shadow-sm">
+            <div class="card-body">
+              <h1 class="h3 mb-3">Operadores A &amp; B</h1>
+              <p class="text-muted">Carregue um documento DOCX para receber um ficheiro ZIP com os CSV gerados pelos dois operadores.</p>
+              {% with messages = get_flashed_messages() %}
+                {% if messages %}
+                  <div class="alert alert-warning">
+                    {% for message in messages %}
+                      <div>{{ message }}</div>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              {% endwith %}
+              <form method="post" enctype="multipart/form-data" class="d-grid gap-3">
+                <div>
+                  <label for="document" class="form-label">Documento DOCX</label>
+                  <input class="form-control" type="file" id="document" name="document" accept=".docx" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Processar documento</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated CLI script that recreates the operator A/B CSV outputs and optional ZIP bundle
- document how to run the new CLI flow and highlight checking for requirements.txt before installing

## Testing
- python -m compileall SpacyOperator.py cne_ai webapp scripts

------
https://chatgpt.com/codex/tasks/task_b_68de77f4bd548321a450e4550ce3ffc4