### PR TITLE
Fix optional docx import guard

### DIFF
--- a/cne_ai/docx_tables.py
+++ b/cne_ai/docx_tables.py
@@ -5,10 +5,6 @@ from pathlib import Path
 from typing import List, Sequence, Type, Union
 import csv
 
-try:  # pragma: no cover - optional dependency in some environments
-
-import csv
-
 try:  # pragma: no cover - optional dependency in the execution environment
     from docx import Document
 except ImportError as exc:  # pragma: no cover - error path when dependency missing


### PR DESCRIPTION
## Summary
- remove duplicate csv import from docx_tables
- narrow optional dependency guard to only cover the python-docx import

## Testing
- python -m compileall cne_ai/docx_tables.py

------
https://chatgpt.com/codex/tasks/task_b_68deda6791cc8321950e777edeeed27c